### PR TITLE
Add prototype research portal UI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,11 +1,11 @@
-from flask import Flask, request, render_template_string
+from flask import Flask, request, render_template, render_template_string, redirect, url_for
 import os
 import subprocess
 import uuid
 
 UPLOAD_DIR = os.environ.get("VIIR_UPLOAD_DIR", "/data")
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='static', template_folder='templates')
 
 HTML_FORM = """
 <!doctype html>
@@ -20,8 +20,12 @@ HTML_FORM = """
 <pre>{{output}}</pre>
 """
 
-@app.route('/', methods=['GET', 'POST'])
-def index():
+@app.route('/')
+def home():
+    return render_template('index.html')
+
+@app.route('/runner', methods=['GET', 'POST'])
+def runner():
     output = ''
     uid = uuid.uuid4().hex[:8]
     if request.method == 'POST':
@@ -53,6 +57,18 @@ def index():
             output = e.stdout + '\n' + e.stderr
 
     return render_template_string(HTML_FORM, output=output, uid=uid)
+
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    file = request.files.get('file')
+    if not file or not file.filename:
+        return redirect(url_for('home'))
+    uid = uuid.uuid4().hex[:8]
+    job_dir = os.path.join(UPLOAD_DIR, uid)
+    os.makedirs(job_dir, exist_ok=True)
+    file.save(os.path.join(job_dir, file.filename))
+    return redirect(url_for('home'))
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,0 +1,51 @@
+/* Mock functionality for ViiR web prototype */
+
+function analyzeData() {
+    const input = document.getElementById('analysis-input').value;
+    if (!input.trim()) {
+        alert('Please provide input data.');
+        return;
+    }
+    const wordCount = input.trim().split(/\s+/).length;
+    const result = `Sample analysis complete.\nWord count: ${wordCount}`;
+    document.getElementById('results').textContent = result;
+}
+
+function addNote() {
+    const noteText = document.getElementById('note-text').value;
+    if (!noteText.trim()) return;
+    const notes = document.getElementById('notes');
+    const item = document.createElement('li');
+    item.textContent = noteText;
+    notes.appendChild(item);
+    document.getElementById('note-text').value = '';
+}
+
+function exportCSV() {
+    const csvContent = 'data:text/csv;charset=utf-8,Sample,Value\nA,1\nB,2';
+    const encoded = encodeURI(csvContent);
+    const link = document.createElement('a');
+    link.setAttribute('href', encoded);
+    link.setAttribute('download', 'result.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}
+
+function renderChart() {
+    const canvas = document.getElementById('chart');
+    const ctx = canvas.getContext('2d');
+    const data = [12, 19, 3, 5];
+    const labels = ['A', 'B', 'C', 'D'];
+    const width = canvas.width / data.length;
+    ctx.fillStyle = '#3867d6';
+    data.forEach((val, i) => {
+        const x = i * width + 10;
+        const y = canvas.height - val * 5;
+        const h = val * 5;
+        ctx.fillRect(x, y, width - 20, h);
+        ctx.fillText(labels[i], x + (width - 20) / 2 - 5, canvas.height - 5);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', renderChart);

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,70 @@
+/* Basic styling for ViiR web prototype */
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    color: #333;
+}
+
+header {
+    background: #4B6584;
+    color: white;
+    padding: 10px 20px;
+}
+
+nav {
+    display: flex;
+    gap: 20px;
+}
+
+nav a {
+    color: white;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+nav a:hover {
+    text-decoration: underline;
+}
+
+section {
+    padding: 20px;
+}
+
+.container {
+    max-width: 1000px;
+    margin: auto;
+}
+
+.btn {
+    background: #3867d6;
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn:hover {
+    background: #274b9e;
+}
+
+input[type="file"], textarea, input[type="text"] {
+    width: 100%;
+    margin-bottom: 10px;
+    padding: 8px;
+}
+
+#results {
+    white-space: pre-wrap;
+    background: #f2f2f2;
+    padding: 10px;
+    border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+    nav {
+        flex-direction: column;
+    }
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ViiR Research Portal</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>ViiR Research Portal</h1>
+            <nav>
+                <a href="#home">Home</a>
+                <a href="#analysis">Data Analysis</a>
+                <a href="#visualize">Visualization</a>
+                <a href="#notes">Notes</a>
+                <a href="#upload">Upload</a>
+            </nav>
+        </div>
+    </header>
+
+    <section id="home" class="container">
+        <h2>Welcome</h2>
+        <p>This portal provides mock tools for data analysis, search and visualization built around ViiR.</p>
+    </section>
+
+    <section id="analysis" class="container">
+        <h2>Data Analysis</h2>
+        <textarea id="analysis-input" rows="5" placeholder="Paste data here..."></textarea>
+        <button class="btn" onclick="analyzeData()">Analyze</button>
+        <pre id="results"></pre>
+        <button class="btn" onclick="exportCSV()">Export CSV</button>
+    </section>
+
+    <section id="visualize" class="container">
+        <h2>Visualization</h2>
+        <canvas id="chart" width="400" height="200"></canvas>
+    </section>
+
+    <section id="notes" class="container">
+        <h2>Notes</h2>
+        <textarea id="note-text" rows="3" placeholder="Add a note..."></textarea>
+        <button class="btn" onclick="addNote()">Add Note</button>
+        <ul id="notes"></ul>
+    </section>
+
+    <section id="upload" class="container">
+        <h2>File Upload</h2>
+        <form action="/upload" method="post" enctype="multipart/form-data">
+            <input type="file" name="file">
+            <input type="text" name="description" placeholder="Description">
+            <button class="btn" type="submit">Upload</button>
+        </form>
+    </section>
+
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a basic web frontend in `app/templates/index.html`
- style the page via `app/static/style.css`
- add Javascript mock features such as analysis and chart drawing
- extend flask server to serve the new page and handle uploads

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6849201471dc8320928c2bd15ace4c94